### PR TITLE
feat: add cache clearing and warmup before benchmarks

### DIFF
--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -10,7 +10,7 @@ use tokio::{
     io::{AsyncBufReadExt, BufReader},
     process::Command,
 };
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 /// Manages benchmark execution using reth-bench
 pub struct BenchmarkRunner {
@@ -27,6 +27,129 @@ impl BenchmarkRunner {
             jwt_secret: args.jwt_secret_path().to_string_lossy().to_string(),
             wait_time: args.wait_time.clone(),
         }
+    }
+
+    /// Clear filesystem caches (page cache, dentries, and inodes)
+    pub async fn clear_fs_caches() -> Result<()> {
+        info!("Clearing filesystem caches...");
+        
+        // First sync to ensure all pending writes are flushed
+        let sync_output = Command::new("sync")
+            .output()
+            .await
+            .wrap_err("Failed to execute sync command")?;
+            
+        if !sync_output.status.success() {
+            return Err(eyre!("sync command failed"));
+        }
+        
+        // Drop caches - requires sudo/root permissions
+        // 3 = drop pagecache, dentries, and inodes
+        let drop_caches_cmd = Command::new("sudo")
+            .args(["-n", "sh", "-c", "echo 3 > /proc/sys/vm/drop_caches"])
+            .output()
+            .await;
+            
+        match drop_caches_cmd {
+            Ok(output) if output.status.success() => {
+                info!("Successfully cleared filesystem caches");
+                Ok(())
+            }
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                if stderr.contains("sudo: a password is required") {
+                    warn!("Unable to clear filesystem caches: sudo password required");
+                    warn!("For optimal benchmarking, configure passwordless sudo for cache clearing:");
+                    warn!("  echo '$USER ALL=(ALL) NOPASSWD: /bin/sh -c echo\\\\ [0-9]\\\\ \\\\>\\\\ /proc/sys/vm/drop_caches' | sudo tee /etc/sudoers.d/drop_caches");
+                    Ok(())
+                } else {
+                    Err(eyre!("Failed to clear filesystem caches: {}", stderr))
+                }
+            }
+            Err(e) => {
+                warn!("Unable to clear filesystem caches: {}", e);
+                Ok(())
+            }
+        }
+    }
+
+    /// Run a warmup benchmark for cache warming
+    pub async fn run_warmup(&self, from_block: u64, warmup_blocks: u64) -> Result<()> {
+        let to_block = from_block + warmup_blocks;
+        info!(
+            "Running warmup benchmark from block {} to {} ({} blocks)",
+            from_block, to_block, warmup_blocks
+        );
+
+        // Build the reth-bench command for warmup (no output flag)
+        let mut cmd = Command::new("reth-bench");
+        cmd.args([
+            "new-payload-fcu",
+            "--rpc-url",
+            &self.rpc_url,
+            "--jwt-secret",
+            &self.jwt_secret,
+            "--from",
+            &from_block.to_string(),
+            "--to",
+            &to_block.to_string(),
+        ]);
+
+        // Add wait-time argument if provided
+        if let Some(ref wait_time) = self.wait_time {
+            cmd.args(["--wait-time", wait_time]);
+        }
+
+        cmd.stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+
+        // Set process group for consistent signal handling
+        #[cfg(unix)]
+        {
+            cmd.process_group(0);
+        }
+
+        debug!("Executing warmup reth-bench command: {:?}", cmd);
+
+        // Execute the warmup benchmark
+        let mut child = cmd.spawn().wrap_err("Failed to start warmup reth-bench process")?;
+
+        // Stream output at debug level
+        if let Some(stdout) = child.stdout.take() {
+            tokio::spawn(async move {
+                let reader = BufReader::new(stdout);
+                let mut lines = reader.lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    debug!("[WARMUP] {}", line);
+                }
+            });
+        }
+
+        if let Some(stderr) = child.stderr.take() {
+            tokio::spawn(async move {
+                let reader = BufReader::new(stderr);
+                let mut lines = reader.lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    debug!("[WARMUP] {}", line);
+                }
+            });
+        }
+
+        let status = child
+            .wait()
+            .await
+            .wrap_err("Failed to wait for warmup reth-bench")?;
+
+        if !status.success() {
+            return Err(eyre!(
+                "Warmup reth-bench failed with exit code: {:?}",
+                status.code()
+            ));
+        }
+
+        info!("Warmup completed successfully");
+        Ok(())
     }
 
     /// Run a benchmark for the specified block range

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -27,7 +27,7 @@ impl BenchmarkRunner {
             rpc_url: args.rpc_url.clone(),
             jwt_secret: args.jwt_secret_path().to_string_lossy().to_string(),
             wait_time: args.wait_time.clone(),
-            warmup_blocks: args.warmup_blocks,
+            warmup_blocks: args.get_warmup_blocks(),
         }
     }
 
@@ -314,5 +314,40 @@ mod tests {
 
         let runner = BenchmarkRunner::new(&args);
         assert_eq!(runner.wait_time, None);
+    }
+
+    #[test]
+    fn test_warmup_blocks_defaults_to_blocks() {
+        // Test that warmup_blocks defaults to blocks value when not specified
+        let args = Args::try_parse_from([
+            "reth-bench-compare",
+            "--baseline-ref",
+            "main",
+            "--feature-ref",
+            "test",
+            "--blocks",
+            "50",
+        ])
+        .unwrap();
+
+        let runner = BenchmarkRunner::new(&args);
+        assert_eq!(runner.warmup_blocks, 50);
+
+        // Test that explicit warmup_blocks overrides the default
+        let args = Args::try_parse_from([
+            "reth-bench-compare",
+            "--baseline-ref",
+            "main",
+            "--feature-ref",
+            "test",
+            "--blocks",
+            "50",
+            "--warmup-blocks",
+            "25",
+        ])
+        .unwrap();
+
+        let runner = BenchmarkRunner::new(&args);
+        assert_eq!(runner.warmup_blocks, 25);
     }
 }

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -17,6 +17,7 @@ pub struct BenchmarkRunner {
     rpc_url: String,
     jwt_secret: String,
     wait_time: Option<String>,
+    warmup_blocks: u64,
 }
 
 impl BenchmarkRunner {
@@ -26,6 +27,7 @@ impl BenchmarkRunner {
             rpc_url: args.rpc_url.clone(),
             jwt_secret: args.jwt_secret_path().to_string_lossy().to_string(),
             wait_time: args.wait_time.clone(),
+            warmup_blocks: args.warmup_blocks,
         }
     }
 
@@ -74,11 +76,11 @@ impl BenchmarkRunner {
     }
 
     /// Run a warmup benchmark for cache warming
-    pub async fn run_warmup(&self, from_block: u64, warmup_blocks: u64) -> Result<()> {
-        let to_block = from_block + warmup_blocks;
+    pub async fn run_warmup(&self, from_block: u64) -> Result<()> {
+        let to_block = from_block + self.warmup_blocks;
         info!(
             "Running warmup benchmark from block {} to {} ({} blocks)",
-            from_block, to_block, warmup_blocks
+            from_block, to_block, self.warmup_blocks
         );
 
         // Build the reth-bench command for warmup (no output flag)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -93,6 +93,10 @@ pub struct Args {
     #[arg(long, value_name = "DURATION")]
     pub wait_time: Option<String>,
 
+    /// Number of blocks to run for cache warmup after clearing caches
+    #[arg(long, value_name = "N", default_value = "10")]
+    pub warmup_blocks: u64,
+
     #[command(flatten)]
     pub logs: LogArgs,
 
@@ -355,10 +359,9 @@ async fn run_benchmark_workflow(
         // Clear filesystem caches before benchmark
         BenchmarkRunner::clear_fs_caches().await?;
 
-        // Run warmup with 10 blocks to warm up caches
-        const WARMUP_BLOCKS: u64 = 10;
+        // Run warmup to warm up caches
         benchmark_runner
-            .run_warmup(current_tip, WARMUP_BLOCKS)
+            .run_warmup(current_tip)
             .await?;
 
         // Calculate benchmark range

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -352,6 +352,15 @@ async fn run_benchmark_workflow(
         // Store the tip we'll unwind back to
         let original_tip = current_tip;
 
+        // Clear filesystem caches before benchmark
+        BenchmarkRunner::clear_fs_caches().await?;
+
+        // Run warmup with 10 blocks to warm up caches
+        const WARMUP_BLOCKS: u64 = 10;
+        benchmark_runner
+            .run_warmup(current_tip, WARMUP_BLOCKS)
+            .await?;
+
         // Calculate benchmark range
         // Note: reth-bench has an off-by-one error where it consumes the first block
         // of the range, so we add 1 to compensate and get exactly args.blocks blocks

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -93,9 +93,10 @@ pub struct Args {
     #[arg(long, value_name = "DURATION")]
     pub wait_time: Option<String>,
 
-    /// Number of blocks to run for cache warmup after clearing caches
-    #[arg(long, value_name = "N", default_value = "10")]
-    pub warmup_blocks: u64,
+    /// Number of blocks to run for cache warmup after clearing caches.
+    /// If not specified, defaults to the same as --blocks
+    #[arg(long, value_name = "N")]
+    pub warmup_blocks: Option<u64>,
 
     #[command(flatten)]
     pub logs: LogArgs,
@@ -153,6 +154,11 @@ impl Args {
     pub fn output_dir_path(&self) -> PathBuf {
         let expanded = shellexpand::tilde(&self.output_dir);
         PathBuf::from(expanded.as_ref())
+    }
+
+    /// Get the effective warmup blocks value - either specified or defaults to blocks
+    pub fn get_warmup_blocks(&self) -> u64 {
+        self.warmup_blocks.unwrap_or(self.blocks)
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -5,7 +5,7 @@ use alloy_provider::{Provider, ProviderBuilder};
 use alloy_rpc_types_eth::SyncStatus;
 use eyre::{eyre, OptionExt, Result, WrapErr};
 #[cfg(unix)]
-use nix::sys::signal::{kill, killpg, Signal};
+use nix::sys::signal::{killpg, Signal};
 #[cfg(unix)]
 use nix::unistd::Pid;
 use reth_chainspec::Chain;


### PR DESCRIPTION
- Clear filesystem caches (page cache, dentries, inodes) before each benchmark run
- Add 10-block warmup run after cache clearing to warm up caches
- Warmup runs without output directory to minimize overhead
- Handles cases where sudo permissions are not available with warnings

This ensures more consistent benchmark results by starting each run from a known cache state.